### PR TITLE
- Updated leafo/scssphp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"kriswallsmith/assetic": "1.*",
 	"natxet/CssMin": "3.0.*",
 	"leafo/lessphp": "0.5.*",
-	"leafo/scssphp": "0.1.*",
+	"leafo/scssphp": "0.6.*",
 	"ptachoire/cssembed": "1.0.*",
 	"linkorb/jsmin-php": "1.0.*"
     },


### PR DESCRIPTION
Matt,

Love the package, but your leafo/scssphp dependency (0.1.*) points to a really old version of leafo/scssphp that doesn't support @extend, causing the potion:make-assets command to break when it tries to process a SCSS file containing @extend. Updating the dependency to the more recent 0.6*  fixes this issue.