### PR TITLE
Helpers cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,8 @@ You will now see to new Potion artisan commands. The configuration is very well 
 - Resource watching command functionality
 - Support for more filters from Assetic
 
+# License
+[MIT License](LICENSE)
 
+# Author
+[Matthew R. Miller](https://github.com/mattrmiller)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-laravel-potion
-===============
+# laravel-potion
+
 Potion is a pure PHP asset manager for Laravel based off of [Assetic](https://github.com/kriswallsmith/assetic).
 
-###Description
+# Description
 Laravel 5 comes with a great asset manager called Elixir. While there is nothing wrong with Elixir, it requires you to install Node.js, Gulp, and dependent NPM packages on all of your web serves. While there is nothing wrong with this if you have other needs for those technologies, it seemed unnecessary to us to install that stack solely for the sake of handling assets. So we wrote Potion. Potion is a pure PHP solution, based off of [Assetic](https://github.com/kriswallsmith/assetic) that allows you to handle your assets in the same technology stack that your application is written in.
 
 When using Potion the you will often see is "resources" and "assets". Think of resources as the raw resources inside of Laravel resources direction. Think of assets as what Potion will generate and will ultimately be served to visitors.
 
-###Laravel Support
+# Laravel Support
 At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support was easy to implement in code, the time needed to support requests was too much.
 
-###Features
+# Features
  - Fully integrated into Laravels' artisan commands
  - Asset versioning support
  - Asset CDN Url support
@@ -29,7 +29,7 @@ At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support
  	 - JsCompressorFilter from YUI
  	 - ScssphpFilter
  
-###Installation
+# Installation
 1) Add 'classygeeks/potion' package to your composer.json file:
 
 2) Add the Potion Service provider to your config/app.php file under the predefined "providers" array:
@@ -49,7 +49,7 @@ At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support
 
 You will now see to new Potion artisan commands. The configuration is very well documented and should be able to get even the most complex projects going quickly.
 
-###Future Features
+# Future Features
 - Resource watching command functionality
 - Support for more filters from Assetic
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,16 @@ You will now see to new Potion artisan commands. The configuration is very well 
 - Resource watching command functionality
 - Support for more filters from Assetic
 
-# License
-[MIT License](LICENSE)
+# Rules For Contributing
+- Please make sure all changed files are run through gofmt
+- Submit a PR for review
+- Your name will be added below to Contributors
 
 # Author
 [Matthew R. Miller](https://github.com/mattrmiller)
+
+# Contributors
+[Matthew R. Miller](https://github.com/mattrmiller)
+
+# License
+[MIT License](LICENSE)

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"kriswallsmith/assetic": "1.*",
 	"natxet/CssMin": "3.0.*",
 	"leafo/lessphp": "0.5.*",
-	"leafo/scssphp": "0.1.*",
+	"leafo/scssphp": "0.6.*",
 	"ptachoire/cssembed": "1.0.*",
 	"linkorb/jsmin-php": "1.0.*"
     },

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -101,7 +101,7 @@ class BladeHelpers
         $url = self::assetUrl($name, $version);
 
         // Deferred ?
-        $def = $defer ? 'defer' : '';
+        $defer = $defer ? 'defer' : '';
 
         // Return
         return "<script type=\"text/javascript\" src=\"{$url}\" $defer></script>\n";

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -84,9 +84,10 @@ class BladeHelpers
      * Asset Js
      * @param $name
      * @param $version
+     * @param $defer
      * @return bool|string
      */
-    public static function assetJs($name, $version = false)
+    public static function assetJs($name, $version = false, $defer = FALSE)
     {
         // Get cache
         $cache = Cache::get('potion_assets', []);
@@ -99,8 +100,11 @@ class BladeHelpers
         // Url
         $url = self::assetUrl($name, $version);
 
+	// Deferred ?
+	$def = $defer ? 'defer' : '';
+
         // Return
-        return "<script type=\"text/javascript\" src=\"{$url}\"></script>";
+        return "<script type=\"text/javascript\" src=\"{$url}\" $defer></script>";
     }
 
     /**

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -50,7 +50,7 @@ class BladeHelpers
 
         // Version?
         if ($version) {
-            $ret .= "v={$cache[$name]}";
+            $ret .= "?v={$cache[$name]}";
         }
 
         return $ret;
@@ -59,11 +59,11 @@ class BladeHelpers
     /**
      * Asset Css
      * @param $name
-     * @param $rel
      * @param $version
+     * @param $rel
      * @return bool|string
      */
-    public static function assetCss($name, $rel = 'stylesheet', $version = false)
+    public static function assetCss($name, $version = false, $rel = 'stylesheet')
     {
         // Get cache
         $cache = Cache::get('potion_assets', []);

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -100,8 +100,8 @@ class BladeHelpers
         // Url
         $url = self::assetUrl($name, $version);
 
-	// Deferred ?
-	$def = $defer ? 'defer' : '';
+        // Deferred ?
+        $def = $defer ? 'defer' : '';
 
         // Return
         return "<script type=\"text/javascript\" src=\"{$url}\" $defer></script>";

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -77,7 +77,7 @@ class BladeHelpers
         $url = self::assetUrl($name, $version);
 
         // Return
-        return "<link href=\"{$url}\" rel=\"{$rel}\" type=\"text/css\" />";
+        return "<link href=\"{$url}\" rel=\"{$rel}\" type=\"text/css\" />\n";
     }
 
     /**
@@ -104,7 +104,7 @@ class BladeHelpers
         $def = $defer ? 'defer' : '';
 
         // Return
-        return "<script type=\"text/javascript\" src=\"{$url}\" $defer></script>";
+        return "<script type=\"text/javascript\" src=\"{$url}\" $defer></script>\n";
     }
 
     /**
@@ -127,6 +127,6 @@ class BladeHelpers
         $url = self::assetUrl($name, $version);
 
         // Return
-        return "<img src=\"{$url}\" />";
+        return "<img src=\"{$url}\" />\n";
     }
 }

--- a/src/ClassyGeeks/Potion/Console/Command/ClearAssetsCommand.php
+++ b/src/ClassyGeeks/Potion/Console/Command/ClearAssetsCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
+++ b/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/PotionServiceProvider.php
+++ b/src/ClassyGeeks/Potion/PotionServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT


### PR DESCRIPTION
I ran into an issue where I incorrectly assumed the order of parameters between assetCss and the other asset helpers would be similar, but they weren't, so I moved the $rel argument to the end of the argument list so that $name and $version would be the first two arguments on all of the asset helpers.  I recognize this would constitute a backwards-compatibility issue for those using Potion 1.x.

I also needed the ability to set the **defer** attribute on certain JS assets, so I added that optional argument to the assetJs helper.

The assetUrl method was not including a **?** before the cache-busting **v** URL parameter, so I added that.

Lastly, and I know this is a style preference, I think the generated asset HTML tags would almost always be wanted on their own line, so I added a newline character to the HTML returned from each asset helper.