### PR TITLE
Output append

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,8 @@ You will now see to new Potion artisan commands. The configuration is very well 
 - Resource watching command functionality
 - Support for more filters from Assetic
 
+# License
+[MIT License](LICENSE)
 
+# Author
+[Matthew R. Miller](https://github.com/mattrmiller)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-laravel-potion
-===============
+# laravel-potion
+
 Potion is a pure PHP asset manager for Laravel based off of [Assetic](https://github.com/kriswallsmith/assetic).
 
-###Description
+# Description
 Laravel 5 comes with a great asset manager called Elixir. While there is nothing wrong with Elixir, it requires you to install Node.js, Gulp, and dependent NPM packages on all of your web serves. While there is nothing wrong with this if you have other needs for those technologies, it seemed unnecessary to us to install that stack solely for the sake of handling assets. So we wrote Potion. Potion is a pure PHP solution, based off of [Assetic](https://github.com/kriswallsmith/assetic) that allows you to handle your assets in the same technology stack that your application is written in.
 
 When using Potion the you will often see is "resources" and "assets". Think of resources as the raw resources inside of Laravel resources direction. Think of assets as what Potion will generate and will ultimately be served to visitors.
 
-###Laravel Support
+# Laravel Support
 At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support was easy to implement in code, the time needed to support requests was too much.
 
-###Features
+# Features
  - Fully integrated into Laravels' artisan commands
  - Asset versioning support
  - Asset CDN Url support
@@ -29,7 +29,7 @@ At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support
  	 - JsCompressorFilter from YUI
  	 - ScssphpFilter
  
-###Installation
+# Installation
 1) Add 'classygeeks/potion' package to your composer.json file:
 
 2) Add the Potion Service provider to your config/app.php file under the predefined "providers" array:
@@ -49,7 +49,7 @@ At this time Potion only supports Laravel 5.1 or higher. While Laravel 4 support
 
 You will now see to new Potion artisan commands. The configuration is very well documented and should be able to get even the most complex projects going quickly.
 
-###Future Features
+# Future Features
 - Resource watching command functionality
 - Support for more filters from Assetic
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,16 @@ You will now see to new Potion artisan commands. The configuration is very well 
 - Resource watching command functionality
 - Support for more filters from Assetic
 
-# License
-[MIT License](LICENSE)
+# Rules For Contributing
+- Please make sure all changed files are run through gofmt
+- Submit a PR for review
+- Your name will be added below to Contributors
 
 # Author
 [Matthew R. Miller](https://github.com/mattrmiller)
+
+# Contributors
+[Matthew R. Miller](https://github.com/mattrmiller)
+
+# License
+[MIT License](LICENSE)

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"kriswallsmith/assetic": "1.*",
 	"natxet/CssMin": "3.0.*",
 	"leafo/lessphp": "0.5.*",
-	"leafo/scssphp": "0.1.*",
+	"leafo/scssphp": "0.6.*",
 	"ptachoire/cssembed": "1.0.*",
 	"linkorb/jsmin-php": "1.0.*"
     },

--- a/src/ClassyGeeks/Potion/BladeHelpers.php
+++ b/src/ClassyGeeks/Potion/BladeHelpers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/Console/Command/ClearAssetsCommand.php
+++ b/src/ClassyGeeks/Potion/Console/Command/ClearAssetsCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
+++ b/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
@@ -155,6 +155,9 @@ class MakeAssetsCommand extends Command
                 // -- Asset content
                 $asset_content = '';
 
+                // -- Default empty append
+                $outputAppend = '';
+
                 // -- Resources
                 foreach ($potion['resources'] as $resource) {
 
@@ -191,8 +194,14 @@ class MakeAssetsCommand extends Command
                         // -- -- -- File
                         $file_path = $this->config['assets_path'] . DIRECTORY_SEPARATOR . $file_asset->getSourcePath();
 
+                        // -- -- -- Possible outputAppend string
+                        $outputAppend = isset($potion['output_append']) ? $potion['output_append'] : '';
+
                         // -- -- -- Echo
                         $this->info("Processing resource file: {$file_path}");
+
+                        // -- -- -- Append possible $outputAppend (post-echo so original name is shown when reporting resource)
+                        $file_path .= $outputAppend;
 
                         // -- -- -- Make file, or combine
                         if ($potion['output'] !== false) {
@@ -209,7 +218,7 @@ class MakeAssetsCommand extends Command
                             }
 
                             // -- -- -- -- Add to cache
-                            $cache[$file_asset->getSourcePath()] = $this->versionFile($file_path);
+                            $cache[$file_asset->getSourcePath() . $outputAppend] = $this->versionFile($file_path);
                         }
                     }
                 }
@@ -218,7 +227,7 @@ class MakeAssetsCommand extends Command
                 if ($potion['output'] !== false) {
 
                     // -- -- Write to file
-                    $file_path = $this->config['assets_path'] . DIRECTORY_SEPARATOR . $potion['output'];
+                    $file_path = $this->config['assets_path'] . DIRECTORY_SEPARATOR . $potion['output'] . $outputAppend;
 
                     // -- -- Echo
                     $this->info("Writing asset file: {$file_path}");
@@ -229,7 +238,7 @@ class MakeAssetsCommand extends Command
                     }
 
                     // -- -- Add to cache
-                    $cache[$potion['output']] = $this->versionFile($file_path);
+                    $cache[$potion['output'] . $outputAppend] = $this->versionFile($file_path);
                 }
             }
 

--- a/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
+++ b/src/ClassyGeeks/Potion/Console/Command/MakeAssetsCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/ClassyGeeks/Potion/PotionServiceProvider.php
+++ b/src/ClassyGeeks/Potion/PotionServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -48,6 +48,30 @@ return [
         [
             // Resources, relative paths to 'resource_path' above, can be any valid file or glob pattern
             'resources' => [
+                '/css/individual/*.scss'
+            ],
+
+            // Filters to use, from filters below
+            'filters' => [
+                'css_import',
+                'css_rewrite',
+                'css_min',
+            ],
+
+            // Output file name, this signifies you are combining all resources together,
+            // putting false will generate each file with original file names
+            'output' => false,
+
+            //
+            // If specified, this optional string parameter will be concatenated to the end of every asset
+            // published as part of this potion. This can be used regardless of the value provided for the
+            // output parameter.
+            'output_append' => '.css',
+        ],
+
+        [
+            // Resources, relative paths to 'resource_path' above, can be any valid file or glob pattern
+            'resources' => [
                 '/js/global/*.js'
             ],
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Classy Geeks llc. All Rights Reserved
+ * Copyright 2016 Matthew R. Miller via Classy Geeks llc. All Rights Reserved
  * http://classygeeks.com
  * MIT License:
  * http://opensource.org/licenses/MIT


### PR DESCRIPTION
Matt,

You've probably figured out by now that I'm using Potion on project and extending/modifying it to suit my needs.  I know that not everyone will have the same needs I do, but I figured it would be better to submit each of my modifications as pull requests in case you decide some of them are worth integrating with your core project. 

This one  is a new potion configuration option called **output_append**

## My Use Case

Sometimes, especially during development, I want to process multiple SCSS files into individual CSS files that are then included on different pages of my project individually. So, given the following file structure, I might have 3 pages on a project and each would individually want to include its own specific CSS.

    /resources
        /assets
            /sass
                /pages
                    page1.scss
                    page2.scss
                    page3.scss


The only way to do that with Potion right now is to setup three individual potions in the configuration, which grows tiresome as I add more pages to the project.  Instead, I wanted to be able to have a single potion that would export sass/pages/*.scss to individual CSS files. Setting **output = false** gets me part of the way there, but the resulting files keep their exact file names, leading to .scss files, not .css files. 

My solution:  output_append.

This new, optional parameter may be set on any potion, and is simply concatenated to the end of the resulting asset.  Thus the following potion is possible:

         //
        // Page-specific CSS
        [
            // Resources, relative paths to 'resource_path' above, can be any valid file or glob pattern
            'resources' => [
                '/sass/pages/*.scss',
            ],
            'filters' => [
                'css_import',
                'css_rewrite',
                'css_scssphp',
            ],
            'output'    => FALSE, // keep files separate
            'output_append' => '.css'
        ],

That would cause every scss file in /sass/pages to be processed into an individual file that would then have **.css** appended to the resulting asset name, which I could then include individually on any page of my project as required.
